### PR TITLE
[BE] 멤버 계정 잠금 기능 추가

### DIFF
--- a/src/main/java/com/chateat/chatEAT/api/AdminController.java
+++ b/src/main/java/com/chateat/chatEAT/api/AdminController.java
@@ -2,6 +2,7 @@ package com.chateat.chatEAT.api;
 
 import com.chateat.chatEAT.auth.principaldetails.PrincipalDetails;
 import com.chateat.chatEAT.domain.member.request.AuthorizeRoleRequest;
+import com.chateat.chatEAT.domain.member.request.MemberBlockRequest;
 import com.chateat.chatEAT.domain.member.response.AuthorizeRoleResponse;
 import com.chateat.chatEAT.domain.member.response.MemberListPageResponse;
 import com.chateat.chatEAT.domain.member.service.MemberService;
@@ -62,6 +63,20 @@ public class AdminController {
     public ResponseEntity<Void> deleteMember(@AuthenticationPrincipal PrincipalDetails user,
                                              @PathVariable("memberId") Long memberId) {
         memberService.deleteMember(memberId, user.getUsername());
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/blockMember")
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN')")
+    public ResponseEntity<Void> blockMember(@RequestBody final MemberBlockRequest request) {
+        memberService.memberBlock(request.id());
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/unblockMember")
+    @PreAuthorize("hasAnyAuthority('ROLE_ADMIN')")
+    public ResponseEntity<Void> unblockMember(@RequestBody final MemberBlockRequest request) {
+        memberService.memberUnblock(request.id());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/chateat/chatEAT/api/MemberController.java
+++ b/src/main/java/com/chateat/chatEAT/api/MemberController.java
@@ -96,18 +96,4 @@ public class MemberController {
         OAuth2JoinResponse response = memberService.oauth2Join(request);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
-
-//    @PatchMapping("/blockMember") // 나중에 Admin Controller로 이동
-////    @PreAuthorize("hasRole('ADMIN')")
-//    public ResponseEntity<Void> blockMember(@RequestBody final MemberBlockRequest request) {
-//        memberService.memberBlock(request.email());
-//        return ResponseEntity.ok().build();
-//    }
-//
-//    @PatchMapping("/unblockMember") // 나중에 Admin Controller로 이동
-////    @PreAuthorize("hasRole('ADMIN')")
-//    public ResponseEntity<Void> unblockMember(@RequestBody final MemberBlockRequest request) {
-//        memberService.memberUnblock(request.email());
-//        return ResponseEntity.ok().build();
-//    }
 }

--- a/src/main/java/com/chateat/chatEAT/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/chateat/chatEAT/auth/filter/JwtAuthenticationFilter.java
@@ -39,13 +39,21 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
             throws AuthenticationException {
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        LoginDto loginDto = objectMapper.readValue(request.getInputStream(), LoginDto.class);
-        log.info("Attempting authentication for email: {}", loginDto.getEmail());
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                loginDto.getEmail(), loginDto.getPassword());
-        return authenticationManager.authenticate(authenticationToken);
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            LoginDto loginDto = objectMapper.readValue(request.getInputStream(), LoginDto.class);
+            log.info("Attempting authentication for email: {}", loginDto.getEmail());
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                    loginDto.getEmail(), loginDto.getPassword());
+            return authenticationManager.authenticate(authenticationToken);
+        } catch (IOException e) {
+            log.error("Error reading login request: {}", e.getMessage());
+            throw new AuthenticationException("Error reading login request", e) {
+            };
+        } catch (AuthenticationException e) {
+            log.error("Authentication failed: {}", e.getMessage());
+            throw e;
+        }
     }
 
     @Override

--- a/src/main/java/com/chateat/chatEAT/auth/handler/LoginFailureHandler.java
+++ b/src/main/java/com/chateat/chatEAT/auth/handler/LoginFailureHandler.java
@@ -1,6 +1,7 @@
 package com.chateat.chatEAT.auth.handler;
 
 import com.chateat.chatEAT.auth.utils.Responder;
+import com.chateat.chatEAT.domain.member.exception.MemberBlockedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -17,6 +18,11 @@ public class LoginFailureHandler implements AuthenticationFailureHandler {
     public void onAuthenticationFailure(final HttpServletRequest request, final HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
         log.error("Authentication failure : {}", exception.getMessage());
-        Responder.sendErrorResponse(response, HttpStatus.UNAUTHORIZED);
+        if (exception.getCause() instanceof MemberBlockedException) {
+            Responder.sendErrorResponse(response, HttpStatus.UNAUTHORIZED,
+                    "Blocked Account");
+        } else {
+            Responder.sendErrorResponse(response, HttpStatus.UNAUTHORIZED);
+        }
     }
 }

--- a/src/main/java/com/chateat/chatEAT/auth/principaldetails/PrincipalDetailsService.java
+++ b/src/main/java/com/chateat/chatEAT/auth/principaldetails/PrincipalDetailsService.java
@@ -1,6 +1,7 @@
 package com.chateat.chatEAT.auth.principaldetails;
 
 import com.chateat.chatEAT.domain.member.Member;
+import com.chateat.chatEAT.domain.member.exception.MemberBlockedException;
 import com.chateat.chatEAT.domain.member.repository.MemberRepository;
 import com.chateat.chatEAT.global.exception.BusinessLogicException;
 import com.chateat.chatEAT.global.exception.ExceptionCode;
@@ -21,13 +22,18 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        log.info("loadUserByUsername execute, email {}", email);
-        return memberRepository.findByEmail(email)
-                .map(this::createPrincipalDetails)
+        Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> {
                     log.debug("loadUserByUsername exception occur email {}", email);
                     return new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND);
                 });
+
+        if (member.isBlocked()) {
+            log.debug("Blocked user tried to login, email {}", email);
+            throw new MemberBlockedException("비활성화된 계정입니다.");
+        }
+
+        return createPrincipalDetails(member);
     }
 
     private UserDetails createPrincipalDetails(Member member) {

--- a/src/main/java/com/chateat/chatEAT/auth/utils/Responder.java
+++ b/src/main/java/com/chateat/chatEAT/auth/utils/Responder.java
@@ -21,11 +21,20 @@ public class Responder {
         response.getWriter().write(gson.toJson(errorResponse, ErrorResponse.class));
     }
 
+    public static void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message)
+            throws IOException {
+        Gson gson = new Gson();
+        ErrorResponse errorResponse = ErrorResponse.of(status, message);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(status.value());
+        response.getWriter().write(gson.toJson(errorResponse, ErrorResponse.class));
+    }
+
     public static void sendErrorResponse(HttpServletResponse response, ExceptionCode exceptionCode) {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         throw new BusinessLogicException(exceptionCode);
     }
-
+    
     public static void loginSuccessResponse(HttpServletResponse response, Member member) throws IOException {
         Gson gson = new Gson();
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/chateat/chatEAT/config/SecurityConfig.java
+++ b/src/main/java/com/chateat/chatEAT/config/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
     private final PrincipalDetailsService principalDetailsService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomOAuth2MemberService customOAuth2MemberService;
     private final PasswordEncoder passwordEncoder;
 
@@ -66,8 +68,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
-                        .accessDeniedHandler(new CustomAccessDeniedHandler()))
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
                 .with(new CustomFilterConfigurer(), Customizer.withDefaults())
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
                         .requestMatchers("/", "/members/join", "/auth/login", "/auth/reissue",

--- a/src/main/java/com/chateat/chatEAT/domain/member/Member.java
+++ b/src/main/java/com/chateat/chatEAT/domain/member/Member.java
@@ -1,8 +1,19 @@
 package com.chateat.chatEAT.domain.member;
 
 import com.chateat.chatEAT.oauth2.SocialType;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Table(name = "member")
@@ -18,7 +29,8 @@ public class Member {
 
     @Column(nullable = false, unique = true)
     private String email;
-
+    
+    @Column(nullable = false)
     private String password;
 
     @Column(unique = true)

--- a/src/main/java/com/chateat/chatEAT/domain/member/Member.java
+++ b/src/main/java/com/chateat/chatEAT/domain/member/Member.java
@@ -29,7 +29,7 @@ public class Member {
 
     @Column(nullable = false, unique = true)
     private String email;
-    
+
     @Column(nullable = false)
     private String password;
 
@@ -45,10 +45,6 @@ public class Member {
     private String socialId;
 
     private boolean isBlocked = false;
-
-//    private int loginFailureCount;
-//
-//    private static final int MAX_LOGIN_FAILURE_COUNT = 5;
 
     public void authorizeUser() {
         this.role = Role.USER;
@@ -66,24 +62,13 @@ public class Member {
         this.nickname = nickname;
     }
 
-//    public void blockMember() {
-//        this.isBlocked = true;
-//    }
-//
-//    public void unblockMember() {
-//        this.isBlocked = false;
-//    }
-//
-//    public void increaseLoginFailureCount() {
-//        this.loginFailureCount++;
-//        if (this.loginFailureCount >= MAX_LOGIN_FAILURE_COUNT) {
-//            this.isBlocked = true;
-//        }
-//    }
-//
-//    public void resetLoginFailureCount() {
-//        this.loginFailureCount = 0;
-//    }
+    public void blockMember() {
+        this.isBlocked = true;
+    }
+
+    public void unblockMember() {
+        this.isBlocked = false;
+    }
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(this.password);

--- a/src/main/java/com/chateat/chatEAT/domain/member/exception/MemberBlockedException.java
+++ b/src/main/java/com/chateat/chatEAT/domain/member/exception/MemberBlockedException.java
@@ -1,0 +1,9 @@
+package com.chateat.chatEAT.domain.member.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class MemberBlockedException extends AuthenticationException {
+    public MemberBlockedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/chateat/chatEAT/domain/member/request/MemberBlockRequest.java
+++ b/src/main/java/com/chateat/chatEAT/domain/member/request/MemberBlockRequest.java
@@ -1,4 +1,4 @@
 package com.chateat.chatEAT.domain.member.request;
 
-public record MemberBlockRequest(String email) {
+public record MemberBlockRequest(Long id) {
 }

--- a/src/main/java/com/chateat/chatEAT/domain/member/response/MemberListPageResponse.java
+++ b/src/main/java/com/chateat/chatEAT/domain/member/response/MemberListPageResponse.java
@@ -12,12 +12,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberListPageResponse {
     private Long id;
+    private boolean isBlocked;
     private String email;
     private String nickname;
     private Role role;
     private SocialType socialType;
 
     public static MemberListPageResponse of(Member member) {
-        return new MemberListPageResponse(member.getId(), member.getEmail(), member.getNickname(), member.getRole(), member.getSocialType());
+        return new MemberListPageResponse(member.getId(), member.isBlocked(), member.getEmail(), member.getNickname(),
+                member.getRole(), member.getSocialType());
     }
 }

--- a/src/main/java/com/chateat/chatEAT/domain/member/service/MemberService.java
+++ b/src/main/java/com/chateat/chatEAT/domain/member/service/MemberService.java
@@ -36,9 +36,9 @@ public interface MemberService {
 
     boolean checkNickname(String nickname);
 
-//    void memberBlock(String email);
-//
-//    void memberUnblock(String email);
+    void memberBlock(Long id);
+
+    void memberUnblock(Long id);
 
     OAuth2JoinResponse oauth2Join(OAuth2JoinRequest request);
 

--- a/src/main/java/com/chateat/chatEAT/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/chateat/chatEAT/domain/member/service/MemberServiceImpl.java
@@ -169,19 +169,19 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findAll(pageable).map(MemberListPageResponse::of);
     }
 
-//    @Override
-//    public void memberBlock(String email) {
-//        Member member = memberRepository.findByEmail(email)
-//                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
-//        member.blockMember();
-//    }
-//
-//    @Override
-//    public void memberUnblock(String email) {
-//        Member member = memberRepository.findByEmail(email)
-//                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
-//        member.unblockMember();
-//    }
+    @Override
+    public void memberBlock(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+        member.blockMember();
+    }
+
+    @Override
+    public void memberUnblock(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+        member.unblockMember();
+    }
 
     @Transactional(readOnly = true)
     public Member findMember(Long id) {

--- a/src/main/java/com/chateat/chatEAT/global/exception/ErrorResponse.java
+++ b/src/main/java/com/chateat/chatEAT/global/exception/ErrorResponse.java
@@ -32,8 +32,16 @@ public class ErrorResponse {
         return new ErrorResponse(status.value(), status.getReasonPhrase());
     }
 
+    public static ErrorResponse of(HttpStatus status, String message) {
+        return new ErrorResponse(status.value(), message);
+    }
+
     public static ErrorResponse of(ExceptionCode exceptionCode) {
         return new ErrorResponse(exceptionCode.getStatus(), exceptionCode.getMessage());
+    }
+
+    public static ErrorResponse of(ExceptionCode exceptionCode, String message) {
+        return new ErrorResponse(exceptionCode.getStatus(), message);
     }
 
     public static ErrorResponse of(BindingResult bindingResult) {

--- a/src/main/java/com/chateat/chatEAT/global/exception/ExceptionCode.java
+++ b/src/main/java/com/chateat/chatEAT/global/exception/ExceptionCode.java
@@ -15,6 +15,7 @@ public enum ExceptionCode {
     LOCKED_MEMBER(403, "비활성화된 계정입니다."),
     NOT_SOCIAL_MEMBER(404, "소셜 로그인 회원이 아닙니다."),
     WRONG_ROLE(400, "올바르지 않은 Role 입니다."),
+    MEMBER_BLOCKED(403, "비활성화된 계정입니다."),
 
     // Security, JWT
     NO_ACCESS_TOKEN(403, "토큰에 권한 정보가 존재하지 않습니다."),

--- a/src/main/java/com/chateat/chatEAT/oauth2/CustomOAuth2MemberService.java
+++ b/src/main/java/com/chateat/chatEAT/oauth2/CustomOAuth2MemberService.java
@@ -3,10 +3,15 @@ package com.chateat.chatEAT.oauth2;
 import com.chateat.chatEAT.auth.principaldetails.PrincipalDetails;
 import com.chateat.chatEAT.domain.member.Member;
 import com.chateat.chatEAT.domain.member.repository.MemberRepository;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -20,6 +25,7 @@ import org.springframework.stereotype.Service;
 public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -58,6 +64,70 @@ public class CustomOAuth2MemberService extends DefaultOAuth2UserService {
                     oAuth2Attributes.getOAuth2MemberInfo().getEmail() + "&socialType=" + existingSocialType);
         }
         Member createdMember = oAuth2Attributes.toEntity(socialType, oAuth2Attributes.getOAuth2MemberInfo());
+        createdMember.updatePassword(passwordEncoder, getRandomPassword(10));
         return memberRepository.save(createdMember);
+    }
+
+    private static final char[] rndAllCharacters = new char[]{
+            //number
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            //uppercase
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            //lowercase
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            //special symbols
+            '@', '$', '!', '%', '*', '?', '&'
+    };
+
+    private static final char[] numberCharacters = new char[]{
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'
+    };
+
+    private static final char[] uppercaseCharacters = new char[]{
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
+    };
+
+    private static final char[] lowercaseCharacters = new char[]{
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+    };
+
+    private static final char[] specialSymbolCharacters = new char[]{
+            '@', '$', '!', '%', '*', '?', '&'
+    };
+
+    private String getRandomPassword(int length) {
+        SecureRandom random = new SecureRandom();
+        StringBuilder stringBuilder = new StringBuilder();
+
+        List<Character> passwordCharacters = new ArrayList<>();
+
+        int numberCharactersLength = numberCharacters.length;
+        passwordCharacters.add(numberCharacters[random.nextInt(numberCharactersLength)]);
+
+        int uppercaseCharactersLength = uppercaseCharacters.length;
+        passwordCharacters.add(uppercaseCharacters[random.nextInt(uppercaseCharactersLength)]);
+
+        int lowercaseCharactersLength = lowercaseCharacters.length;
+        passwordCharacters.add(lowercaseCharacters[random.nextInt(lowercaseCharactersLength)]);
+
+        int specialSymbolCharactersLength = specialSymbolCharacters.length;
+        passwordCharacters.add(specialSymbolCharacters[random.nextInt(specialSymbolCharactersLength)]);
+
+        int rndAllCharactersLength = rndAllCharacters.length;
+        for (int i = 0; i < length - 4; i++) {
+            passwordCharacters.add(rndAllCharacters[random.nextInt(rndAllCharactersLength)]);
+        }
+
+        Collections.shuffle(passwordCharacters);
+
+        for (Character character : passwordCharacters) {
+            stringBuilder.append(character);
+        }
+
+        return stringBuilder.toString();
     }
 }


### PR DESCRIPTION
## 🌲 작업한 브랜치
- feature/admin-api

## 📚 작업한 내용
- 멤버 계정 잠금 기능을 추가하였습니다.
- 잠금 계정이 로그인을 시도할 경우 예외 처리를 추가하였습니다.

## ❗이슈 사항
- Spring security 특성상 AuthenticationException의 경우 401 unauthorized의 오류 메세지만 출력되었습니다.
-> AuthenticationException 하위에 추가로 커스텀 예외를 만들어서 메세지를 수정하였습니다.

## 🤔 궁금한 점
